### PR TITLE
semver and git-flow fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ php-rql-parser - A PHP RQL Parsing Library
 This is a small RQL (Resource Query Language) parsing library written in PHP (a port of the js implementation at https://github.com/persvr/rql/),
 allowing a flexible integration of your own business logic and into your application, while still having the parsing logic decoupled. Read on if this is what you need.. ;-)  
 
+This package adheres to [SemVer](http://semver.org/spec/v2.0.0.html) versioning. It will be considered stable after reaching 2.x since the initial 1.x release is
+considered too buggy at the moment.
+
 ## How to use
 
 Basically, this library consists of the following parts:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ allowing a flexible integration of your own business logic and into your applica
 This package adheres to [SemVer](http://semver.org/spec/v2.0.0.html) versioning. It will be considered stable after reaching 2.x since the initial 1.x release is
 considered too buggy at the moment.
 
+It uses a github version of [git-flow](http://nvie.com/posts/a-successful-git-branching-model/) in which new features and bugfixes must be merged to develop
+using a github pull request. It uses the standard git-flow naming conventions with the addition of a 'v' prefix to version tags.
+
 ## How to use
 
 Basically, this library consists of the following parts:


### PR DESCRIPTION
This adds documentation on our use of git-flow and SemVer. After merging we should also rm the `releases/v1.0.0` branch since the lib has already been released to packagist.
