### PR TITLE
acceptance testing for mongodb (closes GRV-1286 and #4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: php
+services: mongodb
 before_script:
+  - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - composer install --dev --no-interaction
   - wget https://scrutinizer-ci.com/ocular.phar
 php:

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     "require": {
         "php": "~5.4"
     },
+    "suggest": {
+        "doctrine/mongodb-odm": "Needs ~1.0 if you want to use Graviton\\Rql\\Queriable\\MongoOdm."
+    },
     "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,13 @@
         }
     ],
     "autoload": {
-        "psr-0": { "Graviton": "lib/"}
+        "psr-0": { "Graviton": ["lib/", "test/"]}
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "squizlabs/php_codesniffer": "~2.2"
+        "squizlabs/php_codesniffer": "~2.2",
+        "doctrine/mongodb-odm": "1.0.0-BETA11@dev",
+        "doctrine/data-fixtures": "~1.0"
     },
     "require": {
         "php": "~5.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "069b8b93adcb2656d3277d3ddf9d613c",
+    "hash": "2d1ee40b75c8720c7c16fe432ce30274",
     "packages": [],
     "packages-dev": [
         {
@@ -873,17 +873,17 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.3",
+            "version": "v2.6.4",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "82462a90848a52c2533aa6b598b107d68076b018"
+                "reference": "60ed7751671113cf1ee7d7778e691642c2e9acd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/82462a90848a52c2533aa6b598b107d68076b018",
-                "reference": "82462a90848a52c2533aa6b598b107d68076b018",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/60ed7751671113cf1ee7d7778e691642c2e9acd8",
+                "reference": "60ed7751671113cf1ee7d7778e691642c2e9acd8",
                 "shasum": ""
             },
             "require": {
@@ -916,7 +916,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-03 15:33:07"
+            "time": "2015-01-25 04:39:26"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,416 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2d1ee40b75c8720c7c16fe432ce30274",
+    "hash": "fff9025316d4369ab50b9235ecf08349",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "eeda578cbe24a170331a1cfdf78be723412df7a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/eeda578cbe24a170331a1cfdf78be723412df7a4",
+                "reference": "eeda578cbe24a170331a1cfdf78be723412df7a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Annotations\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2014-12-20 20:49:38"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "2346085d2b027b233ae1d5de59b07440b9f288c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/2346085d2b027b233ae1d5de59b07440b9f288c8",
+                "reference": "2346085d2b027b233ae1d5de59b07440b9f288c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=3.7",
+                "predis/predis": "~0.8",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Cache\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2015-01-15 20:38:55"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "b99c5c46c87126201899afe88ec490a25eedd6a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/b99c5c46c87126201899afe88ec490a25eedd6a2",
+                "reference": "b99c5c46c87126201899afe88ec490a25eedd6a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2014-02-03 23:07:43"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "5db6ab40e4c531f14dad4ca96a394dfce5d4255b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/5db6ab40e4c531f14dad4ca96a394dfce5d4255b",
+                "reference": "5db6ab40e4c531f14dad4ca96a394dfce5d4255b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2014-05-21 19:28:51"
+        },
+        {
+            "name": "doctrine/data-fixtures",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "b4a135c7db56ecc4602b54a2184368f440cac33e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/b4a135c7db56ecc4602b54a2184368f440cac33e",
+                "reference": "b4a135c7db56ecc4602b54a2184368f440cac33e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.2,<2.5-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/orm": ">=2.2,<2.5-dev"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\DataFixtures": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "time": "2013-07-10 17:04:07"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "0bcb2e79d8571787f18b7eb036ed3d004908e604"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/0bcb2e79d8571787f18b7eb036ed3d004908e604",
+                "reference": "0bcb2e79d8571787f18b7eb036ed3d004908e604",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2014-12-20 21:24:13"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.4",
@@ -60,6 +467,313 @@
                 "instantiate"
             ],
             "time": "2014-10-13 12:58:55"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "doctrine/mongodb",
+            "version": "1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/mongodb.git",
+                "reference": "3b97082b1526406a3e8ddc294713b89d6f460f59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/mongodb/zipball/3b97082b1526406a3e8ddc294713b89d6f460f59",
+                "reference": "3b97082b1526406a3e8ddc294713b89d6f460f59",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.1.0,<2.5-dev",
+                "ext-mongo": ">=1.2.12,<1.7-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "jmikola/geojson": "~1.0"
+            },
+            "suggest": {
+                "jmikola/geojson": "Support GeoJSON geometry objects in 2dsphere queries"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\MongoDB": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan H. Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com"
+                },
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com"
+                },
+                {
+                    "name": "Kris Wallsmith",
+                    "email": "kris.wallsmith@gmail.com"
+                }
+            ],
+            "description": "Doctrine MongoDB Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "mongodb",
+                "persistence"
+            ],
+            "time": "2015-01-30 15:43:45"
+        },
+        {
+            "name": "doctrine/mongodb-odm",
+            "version": "1.0.0-BETA11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/mongodb-odm.git",
+                "reference": "d6110fa6840370fc49c5492cb6a30d8432ddfa8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/d6110fa6840370fc49c5492cb6a30d8432ddfa8d",
+                "reference": "d6110fa6840370fc49c5492cb6a30d8432ddfa8d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "doctrine/collections": "~1.1",
+                "doctrine/common": "2.4.*",
+                "doctrine/inflector": "~1.0",
+                "doctrine/mongodb": ">=1.1.5,<2.0",
+                "php": ">=5.3.2",
+                "symfony/console": "~2.0"
+            },
+            "require-dev": {
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "symfony/yaml": "Enables the YAML metadata mapping driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\ODM\\MongoDB": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com",
+                    "homepage": "http://avalanche123.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Kris Wallsmith",
+                    "email": "kris.wallsmith@gmail.com",
+                    "homepage": "http://kriswallsmith.net/"
+                },
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com",
+                    "homepage": "http://jmikola.net"
+                }
+            ],
+            "description": "Doctrine MongoDB Object Document Mapper",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "mongodb",
+                "odm",
+                "persistence"
+            ],
+            "time": "2014-06-06 17:50:20"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "phpDocumentor": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2015-02-03 12:10:50"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "~1.0,>=1.0.2",
+                "phpdocumentor/reflection-docblock": "~2.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "http://phpspec.org",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2014-11-17 16:23:49"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -307,16 +1021,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.4.5",
+            "version": "4.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2e8580deebb7d1ac92ac878595e6bffe01069c2a"
+                "reference": "5b578d3865a9128b9c209b011fda6539ec06e7a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2e8580deebb7d1ac92ac878595e6bffe01069c2a",
-                "reference": "2e8580deebb7d1ac92ac878595e6bffe01069c2a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5b578d3865a9128b9c209b011fda6539ec06e7a5",
+                "reference": "5b578d3865a9128b9c209b011fda6539ec06e7a5",
                 "shasum": ""
             },
             "require": {
@@ -326,17 +1040,17 @@
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
+                "phpspec/prophecy": "~1.3.1",
                 "phpunit/php-code-coverage": "~2.0",
                 "phpunit/php-file-iterator": "~1.3.2",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "~1.0.2",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.0",
+                "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.1",
-                "sebastian/environment": "~1.1",
-                "sebastian/exporter": "~1.1",
+                "sebastian/environment": "~1.2",
+                "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/recursion-context": "~1.0",
                 "sebastian/version": "~1.0",
                 "symfony/yaml": "~2.0"
             },
@@ -349,7 +1063,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4.x-dev"
+                    "dev-master": "4.5.x-dev"
                 }
             },
             "autoload": {
@@ -375,7 +1089,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-01-27 16:06:15"
+            "time": "2015-02-05 15:51:19"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -872,6 +1586,63 @@
             "time": "2015-01-21 22:44:05"
         },
         {
+            "name": "symfony/console",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "e44154bfe3e41e8267d7a3794cd9da9a51cfac34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/e44154bfe3e41e8267d7a3794cd9da9a51cfac34",
+                "reference": "e44154bfe3e41e8267d7a3794cd9da9a51cfac34",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-25 04:39:26"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v2.6.4",
             "target-dir": "Symfony/Component/Yaml",
@@ -921,7 +1692,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "doctrine/mongodb-odm": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     processIsolation            = "false"
     stopOnFailure               = "false"
     syntaxCheck                 = "false"
-    bootstrap                   = "test/bootstrap.php">
+    bootstrap                   = "vendor/autoload.php">
   <testsuites>
     <testsuite name="php-rql-parser Test Suite">
       <directory>test/</directory>

--- a/test/Graviton/Rql/DataFixtures/MongoOdm.php
+++ b/test/Graviton/Rql/DataFixtures/MongoOdm.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * small collection of basic features
+ */
+
+namespace Graviton\Rql\DataFixtures;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Graviton\Rql\Queriable\Documents\Foo;
+
+/**
+ * Make up some fixtures for testing
+ *
+ * @category MongoODM
+ * @package  RqlParser
+ * @author   Lucas Bickel <lucas.bickel@swisscom.com>
+ * @license  http://opensource.org/licenses/MIT MIT License (c) 2015 Swisscom
+ * @link     http://swisscom.ch
+ */
+class MongoOdm implements FixtureInterface
+{
+    /**
+     * load fixtures with the passed em
+     *
+     *  @param ObjectManager $manager
+     */
+    public function load (ObjectManager $manager)
+    {
+        $doc = new Foo;
+        $doc->name = 'My First Sprocket';
+        $doc->count = 10;
+
+        $manager->persist($doc);
+
+        $widget = new Foo;
+        $widget->name = 'A Simple Widget';
+        $widget->count = 100;
+
+        $manager->persist($widget);
+
+        $manager->flush();
+    }
+}

--- a/test/Graviton/Rql/DataFixtures/MongoOdm.php
+++ b/test/Graviton/Rql/DataFixtures/MongoOdm.php
@@ -33,6 +33,12 @@ class MongoOdm implements FixtureInterface
 
         $manager->persist($doc);
 
+        $wheel = new Foo;
+        $wheel->name = 'The Third Wheel';
+        $wheel->count = 3;
+
+        $manager->persist($wheel);
+
         $widget = new Foo;
         $widget->name = 'A Simple Widget';
         $widget->count = 100;

--- a/test/Graviton/Rql/Queriable/Documents/Foo.php
+++ b/test/Graviton/Rql/Queriable/Documents/Foo.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * foo document for testing
+ */
+
+namespace Graviton\Rql\Queriable\Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ *
+ * @category MongoODM
+ * @package  RqlParser
+ * @author   Lucas Bickel <lucas.bickel@swisscom.com>
+ * @license  http://opensource.org/licenses/MIT MIT License (c) 2015 Swisscom
+ * @link     http://swisscom.ch
+ */
+class Foo
+{
+    /**
+     * @ODM\Id
+     */
+    private $id;
+
+    /**
+     * @ODM\String
+     */
+    public $name;
+
+    /**
+     * @ODM\Int
+     */
+    public $count;
+}

--- a/test/Graviton/Rql/Queriable/MongoOdmTest.php
+++ b/test/Graviton/Rql/Queriable/MongoOdmTest.php
@@ -27,6 +27,8 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
  */
 class MongoOdmTest extends \PHPUnit_Framework_TestCase
 {
+    private $repo;
+
     /**
      * setup mongo-odm and load fixtures
      *
@@ -43,30 +45,29 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
         $config->setProxyNamespace('Proxies');
         $config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/Documents/'));
 
-        $connection = new Connection();
         $dm = DocumentManager::create(new Connection(), $config);
 
         $loader = new Loader();
         $loader->addFixture(new MongoOdmFixtures());
 
-        $executor = new MongoDbExecutor($dm, new MongoDBPurger());
+        $executor = new MongoDBExecutor($dm, new MongoDBPurger());
         $executor->execute($loader->getFixtures());
 
-        $this->dm = $dm;
+        $this->repo = $dm->getRepository('Graviton\Rql\Queriable\Documents\Foo');
     }
 
     /**
      * @dataProvider basicQueryProvider
      *
-     * @param string $query    rql query string
-     * @param string $expected structure of expected return value
+     * @param string  $query    rql query string
+     * @param array[] $expected structure of expected return value
      *
      * @return void
      */
     public function testBasicQueries($query, $expected)
     {
         $parser = new Query($query);
-        $mongo = new MongoOdm($this->dm->getRepository('Graviton\Rql\Queriable\Documents\Foo'));
+        $mongo = new MongoOdm($this->repo);
 
         $parser->applyToQueriable($mongo);
         $results = $mongo->getDocuments();

--- a/test/Graviton/Rql/Queriable/MongoOdmTest.php
+++ b/test/Graviton/Rql/Queriable/MongoOdmTest.php
@@ -71,11 +71,11 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
         $parser->applyToQueriable($mongo);
         $results = $mongo->getDocuments();
 
-        $this->assertEquals(count($results), count($expected));
+        $this->assertEquals(count($expected), count($results));
 
         foreach ($expected AS $position => $data) {
             foreach ($data AS $name => $value) {
-                $this->assertEquals($results[$position]->$name, $value);
+                $this->assertEquals($value, $results[$position]->$name);
             }
         }
     }

--- a/test/Graviton/Rql/Queriable/MongoOdmTest.php
+++ b/test/Graviton/Rql/Queriable/MongoOdmTest.php
@@ -71,7 +71,7 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
         $parser->applyToQueriable($mongo);
         $results = $mongo->getDocuments();
 
-        $this->assertEquals(count($expected), count($results));
+        $this->assertEquals(count($expected), count($results), 'record count mismatch');
 
         foreach ($expected AS $position => $data) {
             foreach ($data AS $name => $value) {
@@ -94,6 +94,34 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
                     array('name' => 'My First Sprocket')
                 )
             ),
+            'eq OR search' => array(
+                'or(eq(name,My First Sprocket),eq(name,The Third Wheel))', array(
+                    array('name' => 'My First Sprocket'),
+                    array('name' => 'The Third Wheel')
+                )
+            ),
+            'eq OR search with sugar' => array(
+                'eq(name,My First Sprocket)|eq(name,The Third Wheel)', array(
+                    array('name' => 'My First Sprocket'),
+                    array('name' => 'The Third Wheel')
+                )
+            ),
+            'ne search' => array(
+                'ne(name,My First Sprocket)', array(
+                    array('name' => 'The Third Wheel'),
+                    array('name' => 'A Simple Widget'),
+                )
+            ),
+            'eq AND search' => array(
+                'and(eq(name,My First Sprocket),eq(count,10))', array(
+                    array('name' => 'My First Sprocket'),
+                )
+            ),
+            'eq AND search with sugar' => array(
+                'eq(name,My First Sprocket)&eq(count,10)', array(
+                    array('name' => 'My First Sprocket'),
+                )
+            ),
             'gt 10 search' => array(
                 'gt(count,10)', array(
                     array('name' => 'A Simple Widget', 'count' => 100)
@@ -103,6 +131,59 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
                 'gte(count,10)', array(
                     array('name' => 'My First Sprocket'),
                     array('name' => 'A Simple Widget', 'count' => 100)
+                )
+            ),
+            'lt 10 search' => array(
+                'lt(count,10)', array(
+                    array('name' => 'The Third Wheel', 'count' => 3)
+                )
+            ),
+            'lte 10 search' => array(
+                'lte(count,10)', array(
+                    array('name' => 'My First Sprocket', 'count' => 10),
+                    array('name' => 'The Third Wheel', 'count' => 3)
+                )
+            ),
+            'sort by int' => array(
+                'sort(count)', array(
+                    array('count' => 3),
+                    array('count' => 10),
+                    array('count' => 100),
+                )
+            ),
+            'sort by int explicit' => array(
+                'sort(+count)', array(
+                    array('count' => 3),
+                    array('count' => 10),
+                    array('count' => 100),
+                )
+            ),
+            'reverse sort by int' => array(
+                'sort(-count)', array(
+                    array('count' => 100),
+                    array('count' => 10),
+                    array('count' => 3),
+                )
+            ),
+            'string sort' => array(
+                'sort(name)', array(
+                    array('name' => 'A Simple Widget', 'count' => 100),
+                    array('name' => 'My First Sprocket', 'count' => 10),
+                    array('name' => 'The Third Wheel', 'count' => 3),
+                )
+            ),
+            'string sort explicit ' => array(
+                'sort(+name)', array(
+                    array('name' => 'A Simple Widget', 'count' => 100),
+                    array('name' => 'My First Sprocket', 'count' => 10),
+                    array('name' => 'The Third Wheel', 'count' => 3),
+                )
+            ),
+            'reverse string sort' => array(
+                'sort(-name)', array(
+                    array('name' => 'The Third Wheel', 'count' => 3),
+                    array('name' => 'My First Sprocket', 'count' => 10),
+                    array('name' => 'A Simple Widget', 'count' => 100),
                 )
             ),
         );

--- a/test/Graviton/Rql/Queriable/MongoOdmTest.php
+++ b/test/Graviton/Rql/Queriable/MongoOdmTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * acceptence tests for the MongoOdm queriable.
+ */
+
+namespace Graviton\Rql\Queriable;
+
+use Doctrine\MongoDB\Connection;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Graviton\Rql\Query;
+use Graviton\Rql\Queriable\MongoOdm;
+use Graviton\Rql\DataFixtures\MongoOdm as MongoOdmFixtures;
+use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
+use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+
+/**
+ * run tests against local mongodb with loaded fixtures
+ *
+ * @category MongoODM
+ * @package  RqlParser
+ * @author   Lucas Bickel <lucas.bickel@swisscom.com>
+ * @license  http://opensource.org/licenses/MIT MIT License (c) 2015 Swisscom
+ * @link     http://swisscom.ch
+ */
+class MongoOdmTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * setup mongo-odm and load fixtures
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        AnnotationDriver::registerAnnotationClasses();
+
+        $config = new Configuration();
+        $config->setHydratorDir('/tmp/hydrators');
+        $config->setHydratorNamespace('Hydrators');
+        $config->setProxyDir('/tmp/proxies');
+        $config->setProxyNamespace('Proxies');
+        $config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/Documents/'));
+
+        $connection = new Connection();
+        $dm = DocumentManager::create(new Connection(), $config);
+
+        $loader = new Loader();
+        $loader->addFixture(new MongoOdmFixtures());
+
+        $executor = new MongoDbExecutor($dm, new MongoDBPurger());
+        $executor->execute($loader->getFixtures());
+
+        $this->dm = $dm;
+    }
+
+    /**
+     * @dataProvider basicQueryProvider
+     *
+     * @param string $query    rql query string
+     * @param string $expected structure of expected return value
+     *
+     * @return void
+     */
+    public function testBasicQueries($query, $expected)
+    {
+        $parser = new Query($query);
+        $mongo = new MongoOdm($this->dm->getRepository('Graviton\Rql\Queriable\Documents\Foo'));
+
+        $parser->applyToQueriable($mongo);
+        $results = $mongo->getDocuments();
+
+        $this->assertEquals(count($results), count($expected));
+
+        foreach ($expected AS $position => $data) {
+            foreach ($data AS $name => $value) {
+                $this->assertEquals($results[$position]->$name, $value);
+            }
+        }
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function basicQueryProvider()
+    {
+        return array(
+            'eq search for non existant document' => array(
+                'eq(name,Not My Sprocket)', array()
+            ),
+            'eq search for document by name' => array(
+                'eq(name,My First Sprocket)', array(
+                    array('name' => 'My First Sprocket')
+                )
+            ),
+            'gt 10 search' => array(
+                'gt(count,10)', array(
+                    array('name' => 'A Simple Widget', 'count' => 100)
+                )
+            ),
+            'gte 10 search' => array(
+                'gte(count,10)', array(
+                    array('name' => 'My First Sprocket'),
+                    array('name' => 'A Simple Widget', 'count' => 100)
+                )
+            ),
+        );
+
+    }
+
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
I've added support for creating mongodb-fixtures and tests. They run against a local instance of mongodb which is what travis-ci supports.

Adding support for additional checks should be a breeze now, look at `test/Graviton/Rql/Queriable/MongoOdmTest.php` to see how it works. Just take care not to break old tests if you need to add more fixtures.

This closes #4 and GRV-1286.

As to the large amount of failing tests: Further tracking of how we solved the issues that where found by this will be in #6 
