### PR TITLE
Hotfix/handle numeric string

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -22,6 +22,8 @@ class Lexer extends \Doctrine\Common\Lexer
     const T_COMMA             = 8;
     const T_DOT               = 9;
     const T_SLASH             = 10;
+    const T_SINGLE_QUOTE      = 11;
+    const T_DOUBLE_QUOTE      = 12;
 
     const T_EQ    = 100;
     const T_NE    = 101;
@@ -62,6 +64,14 @@ class Lexer extends \Doctrine\Common\Lexer
         '-' => self::T_MINUS,
         '.' => self::T_DOT,
         '/' => self::T_SLASH,
+    );
+
+    /**
+     * @var array<string>
+     */
+    protected static $fieldQuotesMap = array(
+        "'" => self::T_SINGLE_QUOTE,
+        '"' => self::T_DOUBLE_QUOTE,
     );
 
     /**
@@ -124,6 +134,9 @@ class Lexer extends \Doctrine\Common\Lexer
         } elseif (in_array($value, array_keys($this->primitiveMap))) {
             $type = $this->primitiveMap[$value];
 
+        } elseif (in_array($value, array_keys(static::$fieldQuotesMap))) {
+            $type = static::$fieldQuotesMap[$value];
+
         } else {
             $type = self::T_STRING;
         }
@@ -170,5 +183,37 @@ class Lexer extends \Doctrine\Common\Lexer
     public static function isFieldConcatenationChar($typeId)
     {
         return in_array($typeId, static::$fieldConcatenatorMap);
+    }
+
+    /**
+     * Determines that the provided type identifier is part of the field concatenator list.
+     *
+     * @param string $typeId Identifier of the character type
+     *
+     * @return bool
+     */
+    public static function isFieldQuotationChar($typeId)
+    {
+        return in_array($typeId, static::$fieldQuotesMap);
+    }
+
+    /**
+     * @param string $quotationChar Quoting character, like " (double quote)
+     *
+     * @return bool
+     */
+    public static function isOpeningQuotation($quotationChar)
+    {
+        static $quotes = array();
+
+        if (empty($quotes[$quotationChar])) {
+            $quotes[$quotationChar] = 0;
+        }
+
+        ++$quotes[$quotationChar];
+
+        // true : it's the first appearance of the quote
+        // false  : it's the closing quote
+        return 1 === $quotes[$quotationChar]%2;
     }
 }

--- a/src/Parser/ParserUtil.php
+++ b/src/Parser/ParserUtil.php
@@ -64,16 +64,17 @@ class ParserUtil
                 $lexer->moveNext();
                 $string = $string . $lexer->lookahead['value'] . self::getString($lexer);
             }
-        } else if(Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
-            $string = $lexer->lookahead['value'];
-
-            if (true === Lexer::isOpeningQuotation($lexer->lookahead['type']))
-            {
-                $lexer->moveNext();
-                $string .= $lexer->lookahead['value'] . self::getString($lexer);
-            }
         } else {
-            self::syntaxError('no string found');
+            if (Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
+                $string = $lexer->lookahead['value'];
+
+                if (true === Lexer::isOpeningQuotation($lexer->lookahead['type'])) {
+                    $lexer->moveNext();
+                    $string .= $lexer->lookahead['value'] . self::getString($lexer);
+                }
+            } else {
+                self::syntaxError('no string found');
+            }
         }
 
         return $string;

--- a/src/Parser/ParserUtil.php
+++ b/src/Parser/ParserUtil.php
@@ -61,8 +61,19 @@ class ParserUtil
             $string = $lexer->lookahead['value'];
             $glimpse = $lexer->glimpse();
             if (Lexer::isFieldConcatenationChar($glimpse['type'])) {
+
                 $lexer->moveNext();
                 $string = $string . $lexer->lookahead['value'] . self::getString($lexer);
+
+            } elseif (Lexer::isFieldQuotationChar($glimpse['type'])) {
+                $lexer->moveNext();
+
+                if (true === Lexer::isOpeningQuotation($lexer->lookahead['type'])) {
+                    $lexer->moveNext();
+                    $string .= $lexer->lookahead['value'] . self::getString($lexer);
+                } else {
+                    $string .= $lexer->lookahead['value'];
+                }
             }
         } elseif (Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
             $string = $lexer->lookahead['value'];
@@ -70,7 +81,10 @@ class ParserUtil
             if (true === Lexer::isOpeningQuotation($lexer->lookahead['type'])) {
                 $lexer->moveNext();
                 $string .= $lexer->lookahead['value'] . self::getString($lexer);
+            } else {
+                $string .= self::getString($lexer);
             }
+
         } else {
             self::syntaxError('no string found');
         }

--- a/src/Parser/ParserUtil.php
+++ b/src/Parser/ParserUtil.php
@@ -62,11 +62,10 @@ class ParserUtil
             $string = $lexer->lookahead['value'];
             $glimpse = $lexer->glimpse();
             if (Lexer::isFieldConcatenationChar($glimpse['type'])) {
-
                 $lexer->moveNext();
                 $string = $string . $lexer->lookahead['value'] . self::getString($lexer);
-                }
-            } else {
+            }
+        } else {
             self::syntaxError('no string found');
         }
 
@@ -85,14 +84,12 @@ class ParserUtil
         $move && $lexer->moveNext();
 
         if (empty($lexer->lookahead)) {
-
             return $string;
         }
 
         if ($lexer->lookahead['type'] !== Lexer::T_CLOSE_PARENTHESIS) {
             $glimpse = $lexer->glimpse();
             if ($glimpse['type'] === Lexer::T_CLOSE_PARENTHESIS) {
-
                 return $lexer->lookahead['value'];
             }
             $string = $lexer->lookahead['value'] . self::parse($lexer);

--- a/src/Parser/ParserUtil.php
+++ b/src/Parser/ParserUtil.php
@@ -64,17 +64,15 @@ class ParserUtil
                 $lexer->moveNext();
                 $string = $string . $lexer->lookahead['value'] . self::getString($lexer);
             }
-        } else {
-            if (Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
-                $string = $lexer->lookahead['value'];
+        } elseif (Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
+            $string = $lexer->lookahead['value'];
 
-                if (true === Lexer::isOpeningQuotation($lexer->lookahead['type'])) {
-                    $lexer->moveNext();
-                    $string .= $lexer->lookahead['value'] . self::getString($lexer);
-                }
-            } else {
-                self::syntaxError('no string found');
+            if (true === Lexer::isOpeningQuotation($lexer->lookahead['type'])) {
+                $lexer->moveNext();
+                $string .= $lexer->lookahead['value'] . self::getString($lexer);
             }
+        } else {
+            self::syntaxError('no string found');
         }
 
         return $string;

--- a/src/Parser/ParserUtil.php
+++ b/src/Parser/ParserUtil.php
@@ -64,6 +64,14 @@ class ParserUtil
                 $lexer->moveNext();
                 $string = $string . $lexer->lookahead['value'] . self::getString($lexer);
             }
+        } else if(Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
+            $string = $lexer->lookahead['value'];
+
+            if (true === Lexer::isOpeningQuotation($lexer->lookahead['type']))
+            {
+                $lexer->moveNext();
+                $string .= $lexer->lookahead['value'] . self::getString($lexer);
+            }
         } else {
             self::syntaxError('no string found');
         }
@@ -84,6 +92,8 @@ class ParserUtil
             $string = self::getString($lexer, false);
         } elseif ($lexer->lookahead['type'] == Lexer::T_INTEGER) {
             $string = (int) $lexer->lookahead['value'];
+        } elseif (Lexer::isFieldQuotationChar($lexer->lookahead['type'])) {
+            $string = self::getString($lexer, false);
         } else {
             self::syntaxError('no valid argument found');
         }

--- a/test/LexerTest.php
+++ b/test/LexerTest.php
@@ -39,7 +39,9 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function lexerProvider()
     {
         return array(
-            'simple eq' => array('eq(name,foo bar)', array(
+            'simple eq' => array(
+                'eq(name,foo bar)',
+                array(
                     'eq' => Lexer::T_EQ,
                     '(' => Lexer::T_OPEN_PARENTHESIS,
                     'name' => Lexer::T_STRING,
@@ -217,7 +219,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider quotationCharProvider
      *
-     * @param string  $quotationChar Character representing a string quotationChar.
+     * @param string $quotationChar Character representing a string quotationChar.
      *
      * @return void
      */

--- a/test/LexerTest.php
+++ b/test/LexerTest.php
@@ -24,7 +24,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      */
     public function testLexer($rql, $expected)
     {
-        $sut = new \Graviton\Rql\Lexer;
+        $sut = new Lexer;
         $sut->setInput($rql);
         foreach ($expected as $part => $type) {
             $sut->moveNext();
@@ -39,17 +39,22 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function lexerProvider()
     {
         return array(
-            'complex eq search concatenated fields' => array('eq(name-part+test,12)', array(
+            'complex eq search numeric argument field' => array('eq(size,12)', array(
                 'eq' => Lexer::T_EQ,
                 '(' => Lexer::T_OPEN_PARENTHESIS,
-                'name' => Lexer::T_STRING,
-                '-' => Lexer::T_MINUS,
-                'part' => Lexer::T_STRING,
-                '+' => Lexer::T_PLUS,
-                'test' => Lexer::T_STRING,
+                'size' => Lexer::T_STRING,
                 ',' => Lexer::T_COMMA,
                 '12' => Lexer::T_INTEGER,
                 ')' => Lexer::T_CLOSE_PARENTHESIS,
+            )),
+            'eq search quoted argument field' => array('eq(size,"12")', array(
+                'eq' => Lexer::T_EQ,
+                '(' => Lexer::T_OPEN_PARENTHESIS,
+                'size' => Lexer::T_STRING,
+                ',' => Lexer::T_COMMA,
+                '"' => Lexer::T_DOUBLE_QUOTE,
+                '12' => Lexer::T_INTEGER,
+                '"' => Lexer::T_DOUBLE_QUOTE,
             )),
             'complex eq search concatenated field value' => array('eq(name,foo-bar+baz)', array(
                 'eq' => Lexer::T_EQ,
@@ -173,7 +178,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsFieldConcatenationChar($concatenator)
     {
-        $this->assertTrue(\Graviton\Rql\Lexer::isFieldConcatenationChar($concatenator));
+        $this->assertTrue(Lexer::isFieldConcatenationChar($concatenator));
     }
 
     /**
@@ -187,5 +192,44 @@ class LexerTest extends \PHPUnit_Framework_TestCase
             'dot' => array(Lexer::T_DOT),
             'slash' => array(Lexer::T_SLASH),
         );
+    }
+
+    /**
+     * test isOpeningQuotation
+     *
+     * @dataProvider quotationCharProvider
+     *
+     * @return void
+     */
+    public function testIsOpeningQuotation($expected, $quotationChar)
+    {
+        $this->assertSame($expected, Lexer::isOpeningQuotation($quotationChar));
+    }
+
+    /**
+     * @return array
+     */
+    public function quotationCharProvider()
+    {
+        return array(
+            '1st single' => array(true, Lexer::T_SINGLE_QUOTE),
+            '2nd single' => array(false, Lexer::T_SINGLE_QUOTE),
+            '1st double' => array(true, Lexer::T_DOUBLE_QUOTE),
+            '2nd double' => array(false, Lexer::T_DOUBLE_QUOTE),
+        );
+    }
+
+    /**
+     * test set of field concatenators
+     *
+     * @dataProvider quotationCharProvider
+     *
+     * @param string $quotationChar Character representing a string quotationChar.
+     *
+     * @return void
+     */
+    public function testIsFieldQuotationChar($tmp, $quotationChar)
+    {
+        $this->assertTrue(Lexer::isFieldQuotationChar($quotationChar));
     }
 }

--- a/test/LexerTest.php
+++ b/test/LexerTest.php
@@ -39,131 +39,176 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function lexerProvider()
     {
         return array(
-            'complex eq search numeric argument field' => array('eq(size,12)', array(
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'size' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                '12' => Lexer::T_INTEGER,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-            )),
-            'eq search quoted argument field' => array('eq(size,"12")', array(
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'size' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                '"' => Lexer::T_DOUBLE_QUOTE,
-                '12' => Lexer::T_INTEGER,
-                '"' => Lexer::T_DOUBLE_QUOTE,
-            )),
-            'complex eq search concatenated field value' => array('eq(name,foo-bar+baz)', array(
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'name' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                'foo' => Lexer::T_STRING,
-                '-' => Lexer::T_MINUS,
-                'bar' => Lexer::T_STRING,
-                '+' => Lexer::T_PLUS,
-                'baz' => Lexer::T_STRING,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-            )),
-            'simple eq search in array field' => array('eq(metadata.mime,text/plain)', array(
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'metadata' => Lexer::T_STRING,
-                '.' => Lexer::T_DOT,
-                'mime' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                'text' => Lexer::T_STRING,
-                '/' => Lexer::T_SLASH,
-                'plain' => Lexer::T_STRING,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-            )),
-            'simple eq' => array('eq(name,foo bar)', array(
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'name' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                'foo bar' => Lexer::T_STRING,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-            )),
+            'complex eq search numeric argument field' => array(
+                'eq(size,12)',
+                array(
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'size' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    '12' => Lexer::T_INTEGER,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
+            'eq search quoted argument field' => array(
+                'eq(size,"12")',
+                array(
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'size' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    '"' => Lexer::T_DOUBLE_QUOTE,
+                    '12' => Lexer::T_INTEGER,
+                    '"' => Lexer::T_DOUBLE_QUOTE,
+                )
+            ),
+            'complex eq search concatenated field value' => array(
+                'eq(name,foo-bar+baz)',
+                array(
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'name' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    'foo' => Lexer::T_STRING,
+                    '-' => Lexer::T_MINUS,
+                    'bar' => Lexer::T_STRING,
+                    '+' => Lexer::T_PLUS,
+                    'baz' => Lexer::T_STRING,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
+            'simple eq search in array field' => array(
+                'eq(metadata.mime,text/plain)',
+                array(
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'metadata' => Lexer::T_STRING,
+                    '.' => Lexer::T_DOT,
+                    'mime' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    'text' => Lexer::T_STRING,
+                    '/' => Lexer::T_SLASH,
+                    'plain' => Lexer::T_STRING,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
+            'simple eq' => array(
+                'eq(name,foo bar)',
+                array(
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'name' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    'foo bar' => Lexer::T_STRING,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
             'simple ne' => array('ne(name,foo)', array('ne' => Lexer::T_NE)),
-            'simple and' => array('and(eq(name,foo),ne(name,bar))', array(
-                'and' => Lexer::T_AND,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-            )),
-            'integer' => array('eq(count,1)', array(
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'count' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                '1' => Lexer::T_INTEGER
-            )),
-            'simple or' => array('or(eq(name,foo),eq(name,bar))', array(
-                'or' => Lexer::T_OR,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'eq' => Lexer::T_EQ,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-            )),
-            'lt,gt' => array('lt(),gt())', array(
-                'lt' => Lexer::T_LT,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-                ',' => Lexer::T_COMMA,
-                'gt' => Lexer::T_GT,
-            )),
-            'lte,gte' => array('lte(),gte())', array(
-                'lte' => Lexer::T_LTE,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-                ',' => Lexer::T_COMMA,
-                'gte' => Lexer::T_GTE,
-            )),
-            'sort' => array('sort(+count,-name)', array(
-                'sort' => Lexer::T_SORT,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                '+' => Lexer::T_PLUS,
-                'count' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                '-' => Lexer::T_MINUS,
-                'name' => Lexer::T_STRING,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-            )),
-            'like' => array('like(name,fo*)', array(
-                'like' => Lexer::T_LIKE,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'name' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                'fo*' => Lexer::T_STRING,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-             )),
-            'limit' => array('limit(1,2)', array(
-                'limit' => Lexer::T_LIMIT,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                '1' => Lexer::T_INTEGER,
-                ',' => Lexer::T_COMMA,
-                '2' => Lexer::T_INTEGER,
-                ')' => Lexer::T_CLOSE_PARENTHESIS,
-            )),
-            'in tests' => array('in(name,[foo,bar]', array(
-                'in' => Lexer::T_IN,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'name' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                '[' => Lexer::T_OPEN_BRACKET,
-                'foo' => Lexer::T_STRING
-            )),
-            'out tests' => array('out(name,[foo,bar]', array(
-                'out' => Lexer::T_OUT,
-                '(' => Lexer::T_OPEN_PARENTHESIS,
-                'name' => Lexer::T_STRING,
-                ',' => Lexer::T_COMMA,
-                '[' => Lexer::T_OPEN_BRACKET,
-                'foo' => Lexer::T_STRING
-            )),
+            'simple and' => array(
+                'and(eq(name,foo),ne(name,bar))',
+                array(
+                    'and' => Lexer::T_AND,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                )
+            ),
+            'integer' => array(
+                'eq(count,1)',
+                array(
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'count' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    '1' => Lexer::T_INTEGER
+                )
+            ),
+            'simple or' => array(
+                'or(eq(name,foo),eq(name,bar))',
+                array(
+                    'or' => Lexer::T_OR,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'eq' => Lexer::T_EQ,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                )
+            ),
+            'lt,gt' => array(
+                'lt(),gt())',
+                array(
+                    'lt' => Lexer::T_LT,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                    ',' => Lexer::T_COMMA,
+                    'gt' => Lexer::T_GT,
+                )
+            ),
+            'lte,gte' => array(
+                'lte(),gte())',
+                array(
+                    'lte' => Lexer::T_LTE,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                    ',' => Lexer::T_COMMA,
+                    'gte' => Lexer::T_GTE,
+                )
+            ),
+            'sort' => array(
+                'sort(+count,-name)',
+                array(
+                    'sort' => Lexer::T_SORT,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    '+' => Lexer::T_PLUS,
+                    'count' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    '-' => Lexer::T_MINUS,
+                    'name' => Lexer::T_STRING,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
+            'like' => array(
+                'like(name,fo*)',
+                array(
+                    'like' => Lexer::T_LIKE,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'name' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    'fo*' => Lexer::T_STRING,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
+            'limit' => array(
+                'limit(1,2)',
+                array(
+                    'limit' => Lexer::T_LIMIT,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    '1' => Lexer::T_INTEGER,
+                    ',' => Lexer::T_COMMA,
+                    '2' => Lexer::T_INTEGER,
+                    ')' => Lexer::T_CLOSE_PARENTHESIS,
+                )
+            ),
+            'in tests' => array(
+                'in(name,[foo,bar]',
+                array(
+                    'in' => Lexer::T_IN,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'name' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    '[' => Lexer::T_OPEN_BRACKET,
+                    'foo' => Lexer::T_STRING
+                )
+            ),
+            'out tests' => array(
+                'out(name,[foo,bar]',
+                array(
+                    'out' => Lexer::T_OUT,
+                    '(' => Lexer::T_OPEN_PARENTHESIS,
+                    'name' => Lexer::T_STRING,
+                    ',' => Lexer::T_COMMA,
+                    '[' => Lexer::T_OPEN_BRACKET,
+                    'foo' => Lexer::T_STRING
+                )
+            ),
         );
     }
 
@@ -199,6 +244,9 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider quotationCharProvider
      *
+     * @param string $expected      Expected outcome
+     * @param string $quotationChar quotation character (' || ")
+     *
      * @return void
      */
     public function testIsOpeningQuotation($expected, $quotationChar)
@@ -224,7 +272,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider quotationCharProvider
      *
-     * @param string $quotationChar Character representing a string quotationChar.
+     * @param boolean $tmp           not used
+     * @param string  $quotationChar Character representing a string quotationChar.
      *
      * @return void
      */

--- a/test/LexerTest.php
+++ b/test/LexerTest.php
@@ -189,12 +189,12 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider quotationCharProvider
      *
-     * @param string $expected      Expected outcome
      * @param string $quotationChar quotation character (' || ")
+     * @param string $expected      Expected outcome
      *
      * @return void
      */
-    public function testIsOpeningQuotation($expected, $quotationChar)
+    public function testIsOpeningQuotation($quotationChar, $expected)
     {
         $this->assertSame($expected, Lexer::isOpeningQuotation($quotationChar));
     }
@@ -205,10 +205,10 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function quotationCharProvider()
     {
         return array(
-            '1st single' => array(true, Lexer::T_SINGLE_QUOTE),
-            '2nd single' => array(false, Lexer::T_SINGLE_QUOTE),
-            '1st double' => array(true, Lexer::T_DOUBLE_QUOTE),
-            '2nd double' => array(false, Lexer::T_DOUBLE_QUOTE),
+            '1st single' => array(Lexer::T_SINGLE_QUOTE, true),
+            '2nd single' => array(Lexer::T_SINGLE_QUOTE, false),
+            '1st double' => array(Lexer::T_DOUBLE_QUOTE, true),
+            '2nd double' => array(Lexer::T_DOUBLE_QUOTE, false),
         );
     }
 
@@ -217,12 +217,11 @@ class LexerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider quotationCharProvider
      *
-     * @param boolean $tmp           not used
      * @param string  $quotationChar Character representing a string quotationChar.
      *
      * @return void
      */
-    public function testIsFieldQuotationChar($tmp, $quotationChar)
+    public function testIsFieldQuotationChar($quotationChar)
     {
         $this->assertTrue(Lexer::isFieldQuotationChar($quotationChar));
     }

--- a/test/LexerTest.php
+++ b/test/LexerTest.php
@@ -39,62 +39,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function lexerProvider()
     {
         return array(
-            'complex eq search numeric argument field' => array(
-                'eq(size,12)',
-                array(
-                    'eq' => Lexer::T_EQ,
-                    '(' => Lexer::T_OPEN_PARENTHESIS,
-                    'size' => Lexer::T_STRING,
-                    ',' => Lexer::T_COMMA,
-                    '12' => Lexer::T_INTEGER,
-                    ')' => Lexer::T_CLOSE_PARENTHESIS,
-                )
-            ),
-            'eq search quoted argument field' => array(
-                'eq(size,"12")',
-                array(
-                    'eq' => Lexer::T_EQ,
-                    '(' => Lexer::T_OPEN_PARENTHESIS,
-                    'size' => Lexer::T_STRING,
-                    ',' => Lexer::T_COMMA,
-                    '"' => Lexer::T_DOUBLE_QUOTE,
-                    '12' => Lexer::T_INTEGER,
-                    '"' => Lexer::T_DOUBLE_QUOTE,
-                )
-            ),
-            'complex eq search concatenated field value' => array(
-                'eq(name,foo-bar+baz)',
-                array(
-                    'eq' => Lexer::T_EQ,
-                    '(' => Lexer::T_OPEN_PARENTHESIS,
-                    'name' => Lexer::T_STRING,
-                    ',' => Lexer::T_COMMA,
-                    'foo' => Lexer::T_STRING,
-                    '-' => Lexer::T_MINUS,
-                    'bar' => Lexer::T_STRING,
-                    '+' => Lexer::T_PLUS,
-                    'baz' => Lexer::T_STRING,
-                    ')' => Lexer::T_CLOSE_PARENTHESIS,
-                )
-            ),
-            'simple eq search in array field' => array(
-                'eq(metadata.mime,text/plain)',
-                array(
-                    'eq' => Lexer::T_EQ,
-                    '(' => Lexer::T_OPEN_PARENTHESIS,
-                    'metadata' => Lexer::T_STRING,
-                    '.' => Lexer::T_DOT,
-                    'mime' => Lexer::T_STRING,
-                    ',' => Lexer::T_COMMA,
-                    'text' => Lexer::T_STRING,
-                    '/' => Lexer::T_SLASH,
-                    'plain' => Lexer::T_STRING,
-                    ')' => Lexer::T_CLOSE_PARENTHESIS,
-                )
-            ),
-            'simple eq' => array(
-                'eq(name,foo bar)',
-                array(
+            'simple eq' => array('eq(name,foo bar)', array(
                     'eq' => Lexer::T_EQ,
                     '(' => Lexer::T_OPEN_PARENTHESIS,
                     'name' => Lexer::T_STRING,

--- a/test/Parser/ParserUtilTest.php
+++ b/test/Parser/ParserUtilTest.php
@@ -53,10 +53,8 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetStringLogicExpectingException()
     {
-        $typeNotString = '([],foo)';
-
         $lexer = new Lexer();
-        $lexer->setInput($typeNotString);
+        $lexer->setInput('([],foo)');
 
         ParserUtil::parseStart($lexer);
 
@@ -73,7 +71,8 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
     public function testParseEnd()
     {
         $lexer = new Lexer();
-        $lexer->setInput('(jon,doe)');
+        $lexer->setInput('eq(jon,doe)');
+        $lexer->moveNext();
         $lexer->moveNext();
         $lexer->moveNext();
         $lexer->moveNext();
@@ -90,7 +89,7 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
     public function testParseEndExpectingException()
     {
         $lexer = new Lexer();
-        $lexer->setInput('(jon,doe)');
+        $lexer->setInput('eq(jon,doe)');
 
         $this->setExpectedException('\LogicException');
 
@@ -112,8 +111,6 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
         $lexer = new Lexer();
         $lexer->setInput($rql);
 
-        ParserUtil::parseStart($lexer);
-
         $this->assertEquals($expected, ParserUtil::parseArgument($lexer));
     }
 
@@ -123,11 +120,14 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
     public function rqlStringProvider()
     {
         return array(
-            'string' => array('jon', '(jon, doe)'),
-            'numeric' => array('12', '(12, doe)'),
-            'quotation' => array('"12"', '("12", doe)'),
-            'boolean (true)' => array(true, '(true, doe)'),
-            'boolean (false)' => array(false, '(false, doe)'),
+            'string' => array('jon', 'jon'),
+            'numeric' => array('12', '12'),
+            'quotation' => array('"12"', '"12"'),
+            'boolean (true)' => array(true, 'true'),
+            'boolean (false)' => array(false, 'false'),
+            'multiple, encapsulated quotation' => array("\"Hans 'Housi' Wale-Sepp\"", "\"Hans 'Housi' Wale-Sepp\""),
+            'apostrophe quotation' => array("it's a cake!!", "it's a cake!!"),
+            'multiple quotation with apostrophe' => array("it's a \"cake\" \"blaster\"!!", "it's a \"cake\" \"blaster\"!!"),
         );
     }
 

--- a/test/Parser/ParserUtilTest.php
+++ b/test/Parser/ParserUtilTest.php
@@ -64,4 +64,82 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
 
         ParserUtil::getString($lexer);
     }
+
+    /**
+     * Verify identification of the closing parenthesis
+     *
+     * @return void
+     */
+    public function testParseEnd()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput('(jon,doe)');
+        $lexer->moveNext();
+        $lexer->moveNext();
+        $lexer->moveNext();
+        $lexer->moveNext();
+
+        ParserUtil::parseEnd($lexer);
+    }
+
+    /**
+     * Verify exception handling of parseEnd
+     *
+     * @return void
+     */
+    public function testParseEndExpectingException()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput('(jon,doe)');
+
+        $this->setExpectedException('\LogicException');
+
+        ParserUtil::parseEnd($lexer);
+    }
+
+    /**
+     * Validates the behavior of parseArgument
+     *
+     * @dataProvider rqlStringProvider
+     *
+     * @return void
+     */
+    public function testParseArgument($expected, $rql)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($rql);
+
+        ParserUtil::parseStart($lexer);
+
+        $this->assertEquals($expected, ParserUtil::parseArgument($lexer));
+    }
+
+    /**
+     * @return array
+     */
+    public function rqlStringProvider()
+    {
+        return array(
+            'string' => array('jon', '(jon, doe)'),
+            'numeric' => array('12', '(12, doe)'),
+            'quotation' => array('"12"', '("12", doe)'),
+            'boolean (true)' => array(true, '(true, doe)'),
+            'boolean (false)' => array(false, '(false, doe)'),
+        );
+    }
+
+    /**
+     * Validates the exception handling of parseArgument
+     *
+     * @return void
+     */
+    public function testParseArgumentExpectingException()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput('()');
+
+        $this->setExpectedException('\LogicException');
+
+        ParserUtil::parseArgument($lexer);
+    }
 }

--- a/test/Parser/ParserUtilTest.php
+++ b/test/Parser/ParserUtilTest.php
@@ -127,7 +127,8 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
             'boolean (false)' => array(false, 'false'),
             'multiple, encapsulated quotation' => array("\"Hans 'Housi' Wale-Sepp\"", "\"Hans 'Housi' Wale-Sepp\""),
             'apostrophe quotation' => array("it's a cake!!", "it's a cake!!"),
-            'multiple quotation with apostrophe' => array("it's a \"cake\" \"blaster\"!!", "it's a \"cake\" \"blaster\"!!"),
+            'multiple quotation with apostrophe' =>
+                array("it's a \"cake\" \"blaster\"!!", "it's a \"cake\" \"blaster\"!!"),
         );
     }
 

--- a/test/Parser/ParserUtilTest.php
+++ b/test/Parser/ParserUtilTest.php
@@ -102,6 +102,9 @@ class ParserUtilTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider rqlStringProvider
      *
+     * @param string $expected Expected outcome
+     * @param string $rql      RQL-Query string
+     *
      * @return void
      */
     public function testParseArgument($expected, $rql)

--- a/test/ParserTest.php
+++ b/test/ParserTest.php
@@ -41,6 +41,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $eqAST = new AST\EqOperation;
         $eqAST->setProperty('name');
+        $eqAST->setValue('"12"');
+        $tests['simple eq with numeric in double quotes'] = array('eq(name,"12")', $eqAST);
+
+        $eqAST = new AST\EqOperation;
+        $eqAST->setProperty('name');
+        $eqAST->setValue("'12'");
+        $tests['simple eq with numeric in single quotes'] = array("eq(name,'12')", $eqAST);
+
+        $eqAST = new AST\EqOperation;
+        $eqAST->setProperty('name');
         $eqAST->setValue('foo');
         $tests['simple eq'] = array('eq(name,foo)', $eqAST);
 
@@ -153,5 +163,19 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $tests['boolean false in AST'] = array('eq(name,false)', $booleanFalseAST);
 
         return $tests;
+    }
+
+    /**
+     * Test parser exception handling
+     *
+     * @return void
+     */
+    public function testParserExpectingException()
+    {
+        $sut = \Graviton\Rql\Parser::createParser("eq(name,'\"12\"')");
+
+        $this->setExpectedException('\\LogicException', 'no string found');
+
+        $sut->getAST();
     }
 }


### PR DESCRIPTION
this patch makes it possible to use per example:

```
?q=eq(size,"12") 
?q=eq(size,'12') 
```

as rql query string.
