### PR TITLE
Fix like() support in nested cases

### DIFF
--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -137,11 +137,11 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
     }
 
     /**
-     * @param Query|Node $query top level query that needs visiting
+     * @param Query $query top level query that needs visiting
      *
      * @return void
      */
-    public function visitQuery($query)
+    public function visitQuery(Query $query)
     {
         if ($query->getSort()) {
             $this->visitSort($query->getSort());

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -113,13 +113,9 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
         } else {
             $node = $query->getQuery();
         }
+
         if ($query instanceof Query) {
-            if ($query->getSort()) {
-                $this->visitSort($query->getSort());
-            }
-            if ($query->getLimit()) {
-                $this->visitLimit($query->getLimit());
-            }
+            $this->visitQuery($query);
         }
 
         if (in_array(get_class($node), array_keys($this->internalMap))) {
@@ -138,6 +134,21 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
         }
 
         return $this->builder;
+    }
+
+    /**
+     * @param Query|Node $query top level query that needs visiting
+     *
+     * @return void
+     */
+    public function visitQuery($query)
+    {
+        if ($query->getSort()) {
+            $this->visitSort($query->getSort());
+        }
+        if ($query->getLimit()) {
+            $this->visitLimit($query->getLimit());
+        }
     }
 
     /**

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -115,7 +115,7 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
         }
         if ($query instanceof Query) {
             if ($query->getSort()) {
-               $this->visitSort($query->getSort());
+                $this->visitSort($query->getSort());
             }
             if ($query->getLimit()) {
                 $this->visitLimit($query->getLimit());
@@ -224,6 +224,7 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
 
     /**
      * @param \Xiag\Rql\Parser\Node\Query\ScalarOperator\LikeNode $node like node
+     * @param boolean                                             $expr should i wrap this in expr
      *
      * @return void
      */

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -129,11 +129,13 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
             return $this->visitLogic($method, $node, $expr);
         }
 
-        if ($query->getSort()) {
-            $this->visitSort($query->getSort());
-        }
-        if ($query->getLimit()) {
-            $this->visitLimit($query->getLimit());
+        if ($query instanceof Query) {
+            if ($query->getSort()) {
+               $this->visitSort($query->getSort());
+            }
+            if ($query->getLimit()) {
+                $this->visitLimit($query->getLimit());
+            }
         }
         return $this->builder;
     }

--- a/test/MongoOdmTest.php
+++ b/test/MongoOdmTest.php
@@ -120,6 +120,13 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
                     array('name' => 'The Third Wheel')
                 ),
             ),
+            'like OR search' => array(
+                'or(like(name,*'.rawurlencode('First').'),like(name,*'.rawurlencode('Wheel').'))',
+                array(
+                    array('name' => 'My First Sprocket'),
+                    array('name' => 'The Third Wheel')
+                )
+            ),
             'ne search' => array(
                 'ne(name,'.rawurlencode('My First Sprocket').')', array(
                     array('name' => 'The Third Wheel'),


### PR DESCRIPTION
`like()` queries now get correctly applied even in nested cases (inside an `or()` for instance).
