### PR TITLE
Implement rql.visit.node event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "require": {
         "php": "~5.4",
         "doctrine/mongodb-odm": "~1.0@beta",
-        "xiag/rql-parser": "^1.0"
+        "xiag/rql-parser": "^1.0",
+        "symfony/event-dispatcher": "^2.6"
     },
     "scripts": {
         "check": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9dbcc8a965d656b219e58cd883869968",
+    "hash": "dad0637fce620610b5be2320b58a9691",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0810d1a4eebb3785866ba724549fa0f9",
+    "hash": "9dbcc8a965d656b219e58cd883869968",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -658,6 +658,64 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2015-07-09 16:07:40"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-18 19:21:56"
         },
         {
             "name": "xiag/rql-parser",

--- a/src/Event/VisitNodeEvent.php
+++ b/src/Event/VisitNodeEvent.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * event for visiting single nodes
+ */
+
+namespace Graviton\Rql\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Xiag\Rql\Parser\AbstractNode;
+
+/**
+ * @author  List of contributors <https://github.com/libgraviton/php-rql-parser/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+final class VisitNodeEvent extends Event
+{
+    /**
+     * @var AbstractNode
+     */
+    private $node;
+
+    /**
+     * @param AbstracNode $node any type of node we are visiting
+     */
+    public function __construct(AbstractNode $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * @return AbstractNode
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * @param AbstractNode $node replacement node
+     *
+     * @return void
+     */
+    public function setNode(AbstractNode $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/src/Events.php
+++ b/src/Events.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * event for visiting single nodes
+ */
+
+namespace Graviton\Rql;
+
+/**
+ * @author  List of contributors <https://github.com/libgraviton/php-rql-parser/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+final class Events
+{
+    /**
+     * the rql.visit.node event is thrown each time an individual query node is being looked at
+     *
+     * @var string
+     */
+    const VISIT_NODE = 'rql.visit.node';
+}

--- a/test/Listener/TestListener.php
+++ b/test/Listener/TestListener.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * simple listener for testing purposes
+ */
+
+namespace Graviton\Rql\Listener;
+
+use Graviton\Rql\Event\VisitNodeEvent;
+use Xiag\Rql\Parser\Node\Query\ScalarOperator\EqNode;
+
+/**
+ * @author  List of contributors <https://github.com/libgraviton/php-rql-parser/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class TestListener
+{
+    /**
+     * @param VisitNodeEvent $event node event to visit
+     *
+     * @return VisitNodeEvent
+     */
+    public function onVisitNode(VisitNodeEvent $event)
+    {
+        $node = $event->getNode();
+        if ($node instanceof EqNode && $node->getValue() == 'replaceme') {
+            $node->setValue('My First Sprocket');
+            $event->setNode($node);
+        }
+        return $event;
+    }
+}


### PR DESCRIPTION
Enable event dispatching by setting an event dispatcher on the visitor using setDispatcher.

This makes it possible to replace parts of a query during visiting. One use case might be if we want to remove parts of a query or add additional default parts. I plan on using it to rewrite `$ref` links we get passed to the internal representation we should be searching for.

I'll probably end up doing a second such visitor that also gets the container builder and gets called at a later stage. I'll have to do some refactoring on the Visitor before this makes sense though.
