### PR TITLE
Switch to setting injection when injecting builder

### DIFF
--- a/src/QueryBuilderAwareInterface.php
+++ b/src/QueryBuilderAwareInterface.php
@@ -5,6 +5,8 @@
 
 namespace Graviton\Rql;
 
+use Doctrine\ODM\MongoDB\Query\Builder;
+
 /**
  * @author  List of contributors <https://github.com/libgraviton/php-rql-parser/graphs/contributors>
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
@@ -13,9 +15,16 @@ namespace Graviton\Rql;
 interface QueryBuilderAwareInterface
 {
     /**
+     * @param Builder $builder query builder
+     *
+     * @return void
+     */
+    public function setBuilder(Builder $builder);
+
+    /**
      * Provides the  Doctrine QueryBuilder
      *
-     * @return \Doctrine\ODM\MongoDB\Query\Builder
+     * @return Builder
      */
     public function getBuilder();
 }

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -79,16 +79,6 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
     ];
 
     /**
-     * create new visitor
-     *
-     * @param Builder $builder MongoDB-ODM querybuilder
-     */
-    public function __construct(Builder $builder)
-    {
-        $this->builder = $builder;
-    }
-
-    /**
      * inject an optional event dispatcher
      *
      * If injected this is used to dispatch some lifecycle events that you may use
@@ -101,6 +91,16 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
     public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @param Builder $builder query builder
+     *
+     * @return void
+     */
+    public function setBuilder(Builder $builder)
+    {
+        $this->builder = $builder;
     }
 
     /**

--- a/test/MongoOdmTest.php
+++ b/test/MongoOdmTest.php
@@ -71,7 +71,8 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped();
         }
 
-        $visitor = new MongoOdm($this->builder);
+        $visitor = new MongoOdm;
+        $visitor->setBuilder($this->builder);
 
         $results = $this->runTestQuery($query, $visitor);
 
@@ -261,7 +262,8 @@ class MongoOdmTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $visitor = new MongoOdm($this->builder);
+        $visitor = new MongoOdm;
+        $visitor->setBuilder($this->builder);
         $visitor->setDispatcher($dispatcher);
 
         $results = $this->runTestQuery($query, $visitor);


### PR DESCRIPTION
This should make it way easier to use the symfony dic downstream using either a configurator or just by getting the class and making it do stuff.
