### PR TITLE
Allow builder to be replaced and node to be zapped

### DIFF
--- a/src/Event/VisitNodeEvent.php
+++ b/src/Event/VisitNodeEvent.php
@@ -45,11 +45,13 @@ final class VisitNodeEvent extends Event
     }
 
     /**
-     * @param AbstractNode $node replacement node
+     * set the current node (or remove it altogether with null)
+     *
+     * @param AbstractNode|null $node replacement node
      *
      * @return void
      */
-    public function setNode(AbstractNode $node)
+    public function setNode(AbstractNode $node = null)
     {
         $this->node = $node;
     }
@@ -60,5 +62,15 @@ final class VisitNodeEvent extends Event
     public function getBuilder()
     {
         return $this->builder;
+    }
+
+    /**
+     * replace builder as needed
+     *
+     * @param Builder builder buidler
+     */
+    public function setBuilder(Builder $builder)
+    {
+        $this->builder = $builder;
     }
 }

--- a/src/Event/VisitNodeEvent.php
+++ b/src/Event/VisitNodeEvent.php
@@ -67,7 +67,9 @@ final class VisitNodeEvent extends Event
     /**
      * replace builder as needed
      *
-     * @param Builder builder buidler
+     * @param Builder $builder replacement query builder
+     *
+     * @return void
      */
     public function setBuilder(Builder $builder)
     {


### PR DESCRIPTION
I need this since I want to build an event listener that adds some stuff to the query builder and them completly removes the node from any further processing in the visitor.
