### PR TITLE
47970 add elemmatch operator

### DIFF
--- a/src/Event/VisitNodeEvent.php
+++ b/src/Event/VisitNodeEvent.php
@@ -25,12 +25,17 @@ final class VisitNodeEvent extends Event
      * @var Builder
      */
     private $builder;
+    /**
+     * @var \SplStack
+     */
+    private $context;
 
     /**
-     * @param AbstracNode $node    any type of node we are visiting
-     * @param Builder     $builder doctrine query builder
+     * @param AbstractNode $node    any type of node we are visiting
+     * @param Builder      $builder doctrine query builder
+     * @param \SplStack    $context context
      */
-    public function __construct(AbstractNode $node, Builder $builder)
+    public function __construct(AbstractNode $node, Builder $builder, \SplStack $context)
     {
         $this->node = $node;
         $this->builder = $builder;
@@ -74,5 +79,15 @@ final class VisitNodeEvent extends Event
     public function setBuilder(Builder $builder)
     {
         $this->builder = $builder;
+    }
+
+    /**
+     * get current context (list of parent nodes)
+     *
+     * @return \SplStack
+     */
+    public function getContext()
+    {
+        return $this->context;
     }
 }

--- a/src/Event/VisitNodeEvent.php
+++ b/src/Event/VisitNodeEvent.php
@@ -39,6 +39,7 @@ final class VisitNodeEvent extends Event
     {
         $this->node = $node;
         $this->builder = $builder;
+        $this->context = $context;
     }
 
     /**

--- a/src/Node/ElemMatchNode.php
+++ b/src/Node/ElemMatchNode.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * ElemMatchNode class file
+ */
+
+namespace Graviton\Rql\Node;
+
+use Xiag\Rql\Parser\Node\AbstractQueryNode;
+use Xiag\Rql\Parser\Node\Query\AbstractComparisonOperatorNode;
+
+/**
+ * elemMatch() node
+ *
+ * @author  List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class ElemMatchNode extends AbstractComparisonOperatorNode
+{
+    /**
+     * @var AbstractQueryNode
+     */
+    protected $query;
+
+    /**
+     * Constructor
+     *
+     * @param string            $field Field
+     * @param AbstractQueryNode $query Query
+     */
+    public function __construct($field, AbstractQueryNode $query)
+    {
+        $this->field = $field;
+        $this->query = $query;
+    }
+
+    /**
+     * Get node name
+     *
+     * @return string
+     */
+    public function getNodeName()
+    {
+        return 'elemMatch';
+    }
+
+    /**
+     * Get query
+     *
+     * @return AbstractQueryNode
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * Set query
+     *
+     * @param AbstractQueryNode $query Query
+     * @return void
+     */
+    public function setQuery(AbstractQueryNode $query)
+    {
+        $this->query = $query;
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Parser class file
+ */
+
+namespace Graviton\Rql;
+
+use Graviton\Rql\TokenParser\ElemMatchTokenParser;
+use Xiag\Rql\Parser\Parser as BaseParser;
+use Xiag\Rql\Parser\TokenParserInterface;
+use Xiag\Rql\Parser\TypeCaster;
+use Xiag\Rql\Parser\ExpressionParser;
+use Xiag\Rql\Parser\TokenParserGroup;
+use Xiag\Rql\Parser\TokenParser;
+
+/**
+ * RQL parser
+ *
+ * @author  List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class Parser extends BaseParser
+{
+    /**
+     * Create default parser
+     *
+     * @return Parser
+     */
+    public static function createDefault()
+    {
+        return (new static(
+            (new ExpressionParser())
+                ->registerTypeCaster('string', new TypeCaster\StringTypeCaster())
+                ->registerTypeCaster('integer', new TypeCaster\IntegerTypeCaster())
+                ->registerTypeCaster('float', new TypeCaster\FloatTypeCaster())
+                ->registerTypeCaster('boolean', new TypeCaster\BooleanTypeCaster())
+        ))
+            ->addTokenParser(new TokenParser\SelectTokenParser())
+            ->addTokenParser(static::createQueryTokenParser())
+            ->addTokenParser(new TokenParser\SortTokenParser())
+            ->addTokenParser(new TokenParser\LimitTokenParser());
+    }
+
+    /**
+     * Create query token parser
+     *
+     * @return TokenParserInterface
+     */
+    protected static function createQueryTokenParser()
+    {
+        $queryTokenParser = new TokenParserGroup();
+        return $queryTokenParser
+            ->addTokenParser(new TokenParser\Query\GroupTokenParser($queryTokenParser))
+            ->addTokenParser(new TokenParser\Query\Basic\LogicOperator\AndTokenParser($queryTokenParser))
+            ->addTokenParser(new TokenParser\Query\Basic\LogicOperator\OrTokenParser($queryTokenParser))
+            ->addTokenParser(new TokenParser\Query\Basic\LogicOperator\NotTokenParser($queryTokenParser))
+            ->addTokenParser(new TokenParser\Query\Basic\ArrayOperator\InTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ArrayOperator\OutTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\EqTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\NeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\LtTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\GtTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\LeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\GeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Basic\ScalarOperator\LikeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ArrayOperator\InTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ArrayOperator\OutTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\EqTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\NeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\LtTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\GtTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\LeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\GeTokenParser())
+            ->addTokenParser(new TokenParser\Query\Fiql\ScalarOperator\LikeTokenParser())
+            ->addTokenParser(new ElemMatchTokenParser($queryTokenParser));
+    }
+}

--- a/src/TokenParser/ElemMatchTokenParser.php
+++ b/src/TokenParser/ElemMatchTokenParser.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * ElemMatchTokenParser class file
+ */
+
+namespace Graviton\Rql\TokenParser;
+
+use Graviton\Rql\Node\ElemMatchNode;
+use Xiag\Rql\Parser\AbstractNode;
+use Xiag\Rql\Parser\Exception\SyntaxErrorException;
+use Xiag\Rql\Parser\Node\AbstractQueryNode;
+use Xiag\Rql\Parser\Token;
+use Xiag\Rql\Parser\TokenParserInterface;
+use Xiag\Rql\Parser\TokenStream;
+use Xiag\Rql\Parser\AbstractTokenParser;
+
+/**
+ * elemMatch() token parser
+ *
+ * @author  List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class ElemMatchTokenParser extends AbstractTokenParser
+{
+    /**
+     * @var TokenParserInterface
+     */
+    private $queryTokenParser;
+
+    /**
+     * Constructor
+     *
+     * @param TokenParserInterface $queryTokenParser Query parser
+     */
+    public function __construct(TokenParserInterface $queryTokenParser)
+    {
+        $this->queryTokenParser = $queryTokenParser;
+    }
+
+    /**
+     * Is current token supported by this parser
+     *
+     * @param TokenStream $tokenStream Token stream
+     * @return bool
+     */
+    public function supports(TokenStream $tokenStream)
+    {
+        return $tokenStream->test(Token::T_OPERATOR, 'elemMatch');
+    }
+
+    /**
+     * Parse
+     *
+     * @param TokenStream $tokenStream Token stream
+     * @return AbstractNode
+     */
+    public function parse(TokenStream $tokenStream)
+    {
+        $tokenStream->expect(Token::T_OPERATOR, 'elemMatch');
+        $tokenStream->expect(Token::T_OPEN_PARENTHESIS);
+
+        $field = $tokenStream->expect(Token::T_STRING)->getValue();
+        $tokenStream->expect(Token::T_COMMA);
+
+        $query = $this->queryTokenParser->parse($tokenStream);
+        if (!$query instanceof AbstractQueryNode) {
+            throw new SyntaxErrorException(
+                sprintf(
+                    '"elemMatch" operator expects parameter "query" to be instance of "%s", "%s" given',
+                    'Xiag\Rql\Parser\Node\AbstractQueryNode',
+                    get_class($query)
+                )
+            );
+        }
+
+        $tokenStream->expect(Token::T_CLOSE_PARENTHESIS);
+
+        return new ElemMatchNode($field, $query);
+    }
+}

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -83,7 +83,7 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      */
     private $internalMap = [
         'Xiag\Rql\Parser\Node\Query\ScalarOperator\LikeNode' => 'visitLike',
-        'Graviton\RestBundle\Rql\Node\ElemMatchNode' => 'visitElemMatch',
+        'Graviton\Rql\Node\ElemMatchNode' => 'visitElemMatch',
     ];
 
     /**

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -131,7 +131,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      *
      * @return Builder|Expr
      */
-    private function recurse($query, $expr = false)
+    protected function recurse($query, $expr = false)
     {
         if ($expr) {
             $node = $query;

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -126,8 +126,8 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
     /**
      * build a querybuilder from the AST
      *
-     * @param Query|Node $query or node
-     * @param bool       $expr  wrap in expr?
+     * @param Query|AbstractNode $query or node
+     * @param bool               $expr  wrap in expr?
      *
      * @return Builder|Expr
      */

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -144,13 +144,14 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
             $node = $query->getQuery();
         }
 
+        $originalNode = $node;
         list($node, $this->builder) = $this->dispatchNodeEvent($node);
 
         if ($query instanceof Query) {
             $this->visitQuery($query);
         }
 
-        $this->context->push($node);
+        $this->context->push($originalNode);
         if (in_array(get_class($node), array_keys($this->internalMap))) {
             $method = $this->internalMap[get_class($node)];
             $builder = $this->$method($node, $expr);

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -188,7 +188,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      *
      * @return void
      */
-    public function visitQuery(Query $query)
+    protected function visitQuery(Query $query)
     {
         if ($query->getSort()) {
             $this->visitSort($query->getSort());

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -292,7 +292,7 @@ final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
         if ($query instanceof \Xiag\Rql\Parser\DataType\Glob) {
             $query = new \MongoRegex($node->getValue()->toRegex());
         }
-        return $this->getField($node->getField(), $expr)->equals($query);
+        $this->getField($node->getField(), $expr)->equals($query);
     }
 
     /**

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -42,7 +42,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      *
      * @var string<string>
      */
-    private $scalarMap = [
+    protected $scalarMap = [
         'Xiag\Rql\Parser\Node\Query\ScalarOperator\EqNode' => 'equals',
         'Xiag\Rql\Parser\Node\Query\ScalarOperator\NeNode' => 'notEqual',
         'Xiag\Rql\Parser\Node\Query\ScalarOperator\LtNode' => 'lt',
@@ -56,7 +56,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      *
      * @var string<string>
      */
-    private $arrayMap = [
+    protected $arrayMap = [
         'Xiag\Rql\Parser\Node\Query\ArrayOperator\InNode' => 'in',
         'Xiag\Rql\Parser\Node\Query\ArrayOperator\OutNode' => 'notIn',
     ];
@@ -66,7 +66,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      *
      * @var string<string>|bool
      */
-    private $queryMap = [
+    protected $queryMap = [
         'Xiag\Rql\Parser\Node\Query\LogicOperator\AndNode' => 'addAnd',
         'Xiag\Rql\Parser\Node\Query\LogicOperator\OrNode' => 'addOr',
     ];
@@ -76,7 +76,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      *
      * @var string<string>
      */
-    private $internalMap = [
+    protected $internalMap = [
         'Xiag\Rql\Parser\Node\Query\ScalarOperator\LikeNode' => 'visitLike',
     ];
 

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -25,7 +25,7 @@ use Xiag\Rql\Parser\Node\Query\AbstractArrayOperatorNode;
  * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
  * @link     http://swisscom.ch
  */
-final class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
+class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
 {
     /**
      * @var Builder

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -82,6 +82,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      */
     protected $internalMap = [
         'Xiag\Rql\Parser\Node\Query\ScalarOperator\LikeNode' => 'visitLike',
+        'Graviton\RestBundle\Rql\Node\ElemMatchNode' => 'visitElemMatch',
     ];
 
     /**
@@ -300,6 +301,20 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
             $query = new \MongoRegex($node->getValue()->toRegex());
         }
         return $this->getField($node->getField(), $expr)->equals($query);
+    }
+
+    /**
+     * Visit elemMatch() node
+     *
+     * @param ElemMatchNode $node elemMatch() node
+     * @param bool          $expr should i wrap this in expr()
+     * @return Builder|Expr
+     */
+    protected function visitElemMatch(ElemMatchNode $node, $expr = false)
+    {
+        return $this
+            ->getField($node->getField(), $expr)
+            ->elemMatch($this->recurse($node->getQuery(), true));
     }
 
     /**

--- a/src/Visitor/MongoOdm.php
+++ b/src/Visitor/MongoOdm.php
@@ -291,7 +291,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
      * @param \Xiag\Rql\Parser\Node\Query\ScalarOperator\LikeNode $node like node
      * @param boolean                                             $expr should i wrap this in expr
      *
-     * @return void
+     * @return Builder|Expr
      */
     protected function visitLike(\Xiag\Rql\Parser\Node\Query\ScalarOperator\LikeNode $node, $expr = false)
     {
@@ -299,7 +299,7 @@ class MongoOdm implements VisitorInterface, QueryBuilderAwareInterface
         if ($query instanceof \Xiag\Rql\Parser\DataType\Glob) {
             $query = new \MongoRegex($node->getValue()->toRegex());
         }
-        $this->getField($node->getField(), $expr)->equals($query);
+        return $this->getField($node->getField(), $expr)->equals($query);
     }
 
     /**

--- a/test/ParserTest.php
+++ b/test/ParserTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * ParserTest class file
+ */
+
+namespace Graviton\Rql;
+
+use Graviton\Rql\Node\ElemMatchNode;
+use Xiag\Rql\Parser\Lexer;
+use Xiag\Rql\Parser\Node;
+use Xiag\Rql\Parser\Query;
+use Xiag\Rql\Parser\QueryBuilder;
+
+/**
+ * @author  List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class ParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test elemMatch() operator
+     *
+     * @param string $rql           RQL query
+     * @param Query  $expectedQuery Expected query
+     * @return void
+     *
+     * @dataProvider dataElemMatchOperator
+     */
+    public function testElemMatchOperator($rql, Query $expectedQuery)
+    {
+        $this->assertEquals(
+            $expectedQuery,
+            Parser::createDefault()->parse((new Lexer())->tokenize($rql))
+        );
+    }
+
+    /**
+     * Data for elemMatch() test
+     *
+     * @return array
+     */
+    public function dataElemMatchOperator()
+    {
+        return [
+            'simple' => [
+                'elemMatch(x,eq(a,1))',
+                (new QueryBuilder())
+                    ->addQuery(new ElemMatchNode('x', new Node\Query\ScalarOperator\EqNode('a', 1)))
+                    ->getQuery(),
+            ],
+            'with logic' => [
+                'a=1&(b=2|elemMatch(x,(c=3|(d=4))))&limit(1,2)',
+                (new QueryBuilder())
+                    ->addQuery(new Node\Query\ScalarOperator\EqNode('a', 1))
+                    ->addQuery(
+                        new Node\Query\LogicOperator\OrNode(
+                            [
+                                new Node\Query\ScalarOperator\EqNode('b', 2),
+                                new ElemMatchNode(
+                                    'x',
+                                    new Node\Query\LogicOperator\OrNode(
+                                        [
+                                            new Node\Query\ScalarOperator\EqNode('c', 3),
+                                            new Node\Query\ScalarOperator\EqNode('d', 4),
+                                        ]
+                                    )
+                                ),
+                            ]
+                        )
+                    )
+                    ->addLimit(new Node\LimitNode(1, 2))
+                    ->getQuery(),
+            ],
+        ];
+    }
+}

--- a/test/TokenParser/ElemMatchTokenParserTest.php
+++ b/test/TokenParser/ElemMatchTokenParserTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * ElemMatchTokenParserTest class file
+ */
+
+namespace Graviton\Rql\TokenParser;
+
+use Graviton\Rql\Node\ElemMatchNode;
+use Xiag\Rql\Parser\Node\Query\ScalarOperator\EqNode;
+use Xiag\Rql\Parser\Token;
+
+/**
+ * @author  List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link    http://swisscom.ch
+ */
+class ElemMatchTokenParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test ElemMatchTokenParser::supports()
+
+     * @return void
+     */
+    public function testSupports()
+    {
+        $expectedResult = __LINE__;
+
+        $queryTokenParser = $this
+            ->getMockBuilder('Xiag\Rql\Parser\TokenParserInterface')
+            ->getMock();
+
+        $tokenStream = $this
+            ->getMockBuilder('Xiag\Rql\Parser\TokenStream')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $tokenStream
+            ->expects($this->once())
+            ->method('test')
+            ->with(Token::T_OPERATOR, 'elemMatch')
+            ->willReturn($expectedResult);
+
+        $tokenParser = new ElemMatchTokenParser($queryTokenParser);
+        $this->assertSame($expectedResult, $tokenParser->supports($tokenStream));
+    }
+
+    /**
+     * Test ElemMatchTokenParser::parse()
+
+     * @return void
+     */
+    public function testParse()
+    {
+        $field = 'field';
+        $query = new EqNode('subfield', 'subvalue');
+        $expectedNode = new ElemMatchNode($field, $query);
+
+        $tokenStream = $this
+            ->getMockBuilder('Xiag\Rql\Parser\TokenStream')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $tokenStream
+            ->expects($this->at(0))
+            ->method('expect')
+            ->with(Token::T_OPERATOR, 'elemMatch');
+        $tokenStream
+            ->expects($this->at(1))
+            ->method('expect')
+            ->with(Token::T_OPEN_PARENTHESIS);
+        $tokenStream
+            ->expects($this->at(2))
+            ->method('expect')
+            ->with(Token::T_STRING)
+            ->willReturn(new Token(Token::T_STRING, $field, 0));
+        $tokenStream
+            ->expects($this->at(3))
+            ->method('expect')
+            ->with(Token::T_COMMA);
+        $tokenStream
+            ->expects($this->at(4))
+            ->method('expect')
+            ->with(Token::T_END, 'parse subquery');
+        $tokenStream
+            ->expects($this->at(5))
+            ->method('expect')
+            ->with(Token::T_CLOSE_PARENTHESIS);
+
+        $queryTokenParser = $this
+            ->getMockBuilder('Xiag\Rql\Parser\TokenParserInterface')
+            ->getMock();
+        $queryTokenParser
+            ->expects($this->once())
+            ->method('parse')
+            ->with($tokenStream)
+            ->willReturnCallback(
+                function () use ($tokenStream, $query) {
+                    $tokenStream->expect(Token::T_END, 'parse subquery');
+                    return $query;
+                }
+            );
+
+        $tokenParser = new ElemMatchTokenParser($queryTokenParser);
+        $this->assertEquals($expectedNode, $tokenParser->parse($tokenStream));
+    }
+}


### PR DESCRIPTION
This is needed for new RQL `elemMatch()` operator.
- Removed `final` modifier from `MongoOdm` to make it extendable
- Added context passing to `VisitNodeEvent`
