### PR TITLE
Add MongoDB TextSearch option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ require 'vendor/autoload.php';
 $rql = 'or(eq(name,foo)&eq(name,bar))';
 
 /** @var \Doctrine\ODM\MongoDB\Query\Builder $builder */
-$visitor = new \Graviton\Rql\Visitor\MongoOdm($builder);
+$visitor = new \Graviton\Rql\Visitor\MongoOdm();
+$visitor->setBuilder($builder);
 $lexer = new \Xiag\Rql\Parser\Lexer;
 $parser = \Xiag\Rql\Parser\Parser::createDefault();
 

--- a/src/Node/SearchNode.php
+++ b/src/Node/SearchNode.php
@@ -5,7 +5,6 @@
 
 namespace Graviton\Rql\Node;
 
-use Xiag\Rql\Parser\AbstractNode;
 use Xiag\Rql\Parser\Node\AbstractQueryNode;
 
 /**
@@ -16,16 +15,38 @@ use Xiag\Rql\Parser\Node\AbstractQueryNode;
 class SearchNode extends AbstractQueryNode
 {
     /**
-     * @var array
+     * Singleton search param
      */
-    protected $searchTerms;
+    private static $instance;
+
+    /** @var bool */
+    private $visited = false;
 
     /**
-     * @param array $searchTerms What search parameters should be added on custurction
+     * @var array
+     */
+    protected $searchTerms = [];
+
+    /**
+     * SearchNode constructor.
+     * @param array $searchTerms list of search items.
      */
     public function __construct(array $searchTerms = [])
     {
         $this->searchTerms = $searchTerms;
+    }
+
+    /**
+     * Singleton implementation
+     * @return SearchNode
+     */
+    public static function getInstance()
+    {
+        if (!self::$instance) {
+            self::$instance = new SearchNode();
+        }
+
+        return self::$instance;
     }
 
     /**
@@ -44,14 +65,50 @@ class SearchNode extends AbstractQueryNode
      */
     public function addSearchTerm($searchTerm)
     {
-        $this->searchTerms[$searchTerm] = $searchTerm;
+        $string = trim($searchTerm);
+        if ($string && !in_array($string, $this->searchTerms)) {
+            $this->searchTerms[] = $string;
+        }
     }
 
     /**
+     * Elements to be searched for
+     *
      * @return array
      */
     public function getSearchTerms()
     {
         return $this->searchTerms;
+    }
+
+    /**
+     * if visited
+     *
+     * @return bool
+     */
+    public function isVisited()
+    {
+        return $this->visited;
+    }
+
+    /**
+     * Set visited
+     *
+     * @param bool $visited Change visit status
+     * @return void
+     */
+    public function setVisited($visited)
+    {
+        $this->visited = $visited;
+    }
+
+    /**
+     * Enable TESTs so the singleton can be reset
+     * @return void
+     */
+    public function resetSearchTerms()
+    {
+        $this->searchTerms = [];
+        $this->visited = false;
     }
 }

--- a/src/TokenParser/SearchTokenParser.php
+++ b/src/TokenParser/SearchTokenParser.php
@@ -8,6 +8,7 @@ namespace Graviton\Rql\TokenParser;
 
 use Graviton\Rql\Node\SearchNode;
 use Xiag\Rql\Parser\AbstractTokenParser;
+use Xiag\Rql\Parser\Exception\UnknownTokenException;
 use Xiag\Rql\Parser\Token;
 use Xiag\Rql\Parser\TokenStream;
 
@@ -21,7 +22,6 @@ use Xiag\Rql\Parser\TokenStream;
  */
 class SearchTokenParser extends AbstractTokenParser
 {
-
     /**
      * @param TokenStream $tokenStream token stream
      * @return SearchNode
@@ -30,13 +30,17 @@ class SearchTokenParser extends AbstractTokenParser
     {
         $tokenStream->expect(Token::T_OPERATOR, 'search');
         $tokenStream->expect(Token::T_OPEN_PARENTHESIS);
-
-        $searchTermsImploded = $this->getParser()->getExpressionParser()->parseScalar($tokenStream);
-        $searchTerms = explode(" ", $searchTermsImploded);
-
+        $searchTerm = $this->getParser()->getExpressionParser()->parseScalar($tokenStream);
+        if (!is_string($searchTerm)) {
+            throw new UnknownTokenException('RQL Search only allows strings');
+        }
         $tokenStream->expect(Token::T_CLOSE_PARENTHESIS);
 
-        return new SearchNode($searchTerms);
+        $searchNode = SearchNode::getInstance();
+        foreach (explode(" ", $searchTerm) as $string) {
+            $searchNode->addSearchTerm($string);
+        }
+        return $searchNode;
     }
 
     /**

--- a/test/TokenParser/SearchTokenParserTest.php
+++ b/test/TokenParser/SearchTokenParserTest.php
@@ -10,8 +10,6 @@ use Graviton\Rql\Node\SearchNode;
 use Graviton\Rql\Parser as GravitonParser;
 use Xiag\Rql\Parser\Node\Query\LogicOperator\AndNode;
 use Xiag\Rql\Parser\Node\SortNode;
-use Xiag\Rql\Parser\Token;
-use Xiag\Rql\Parser\TokenStream;
 
 /**
  * @author  List of contributors <https://github.com/libgraviton/php-rql-parser/graphs/contributors>
@@ -20,6 +18,14 @@ use Xiag\Rql\Parser\TokenStream;
  */
 class SearchTokenParserTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Setup, clear search params
+     * @return void
+     */
+    public function setup()
+    {
+        SearchNode::getInstance()->resetSearchTerms();
+    }
 
     /**
      * Test SearchTokenParser::parse()
@@ -136,7 +142,7 @@ class SearchTokenParserTest extends \PHPUnit_Framework_TestCase
 
         $expectedSearchNodes = [];
         foreach ($terms as $item) {
-            $expectedSearchNodes[] = new SearchNode([$item]);
+            $expectedSearchNodes[] = new SearchNode($terms);
         }
         $expectedNode = new AndNode($expectedSearchNodes);
 
@@ -160,6 +166,7 @@ class SearchTokenParserTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test SearchTokenParser::parse()
+     * Multiple searches should be only one visited
      * @return void
      */
     public function testDashReplaceMultipleAndSortParse()
@@ -170,7 +177,7 @@ class SearchTokenParserTest extends \PHPUnit_Framework_TestCase
 
         $expectedSearchNodes = [];
         foreach ($terms as $item) {
-            $expectedSearchNodes[] = new SearchNode([$item]);
+            $expectedSearchNodes[] = new SearchNode($terms);
         }
         $expectedNode = new AndNode($expectedSearchNodes);
         $expectedSortNode = new SortNode($sort);


### PR DESCRIPTION
Our currently implemented TextSearch in Graviton had now been moved to rql parser library as part of clean-up.